### PR TITLE
feature: Remove for loops to make computation faster

### DIFF
--- a/R/rp_test.R
+++ b/R/rp_test.R
@@ -189,19 +189,16 @@ rp.sample = function(y,k = 16,pars1 = c(100,1),pars2 = c(2,7),seed = NULL){
   if(k <= 1)
     k = 1
 
-  n = length(y);T1 = NULL;T2 = NULL
+  n = length(y);
 
-  for(j in 1:k){
-    yh1 = random.projection(as.numeric(y),shape1 = pars1[1],shape2 = pars1[2])
-    yh2 = random.projection(as.numeric(y),shape1 = pars2[1],shape2 = pars2[2])
-
-    T1 = c(T1,lobato.statistic(yh1) )
-    T1 = c(T1,lobato.statistic(yh2) )
-
-    T2 = c(T2,epps.statistic(yh1) )
-    T2 = c(T2,epps.statistic(yh2) )
+  get_stats = function(pars){
+    yh = random.projection(as.numeric(y),shape1 = pars[1],shape2 = pars[2])
+    c(lobato.statistic(yh),epps.statistic(yh))
   }
-  rp.sample = list(lobato = T1,epps = T2)
+
+  x = cbind(replicate(k, get_stats(pars1)),replicate(k, get_stats(pars2)))
+
+  rp.sample = list(lobato = x[1,],epps = x[2,])
 
   return(rp.sample)
 }
@@ -273,11 +270,9 @@ random.projection = function(y,shape1,shape2,seed = NULL){
   }
   H[C] = sqrt(ch)/(n-C); h = H[C:n]; k = length(h);
 
-  for (j in 1:(k-1))
-    yp[j] = sum(y[1:j]*h[(k-j+1):k])
+  yp[1:(k-1)] = sapply(1:(k-1), function(j) sum(y[1:j]*h[(k-j+1):k]))
 
-  for (j in k:n)
-    yp[j] = sum(y[(j-k+1):j]*h)
+  yp[k:n] = sapply(k:n, function(j) sum(y[(j-k+1):j]*h))
 
   return(yp)
 }

--- a/R/rp_test.R
+++ b/R/rp_test.R
@@ -191,14 +191,20 @@ rp.sample = function(y,k = 16,pars1 = c(100,1),pars2 = c(2,7),seed = NULL){
 
   n = length(y);
 
-  get_stats = function(pars){
-    yh = random.projection(as.numeric(y),shape1 = pars[1],shape2 = pars[2])
-    c(lobato.statistic(yh),epps.statistic(yh))
-  }
+  x1 = parallel::mclapply(1:k, FUN = function(i){
+    yh = random.projection(as.numeric(y),shape1 = pars1[1],shape2 = pars1[2])
+    c(i,lobato.statistic(yh),epps.statistic(yh))
+  })
 
-  x = cbind(replicate(k, get_stats(pars1)),replicate(k, get_stats(pars2)))
+  x2 = parallel::mclapply(1:k, FUN = function(i){
+    yh = random.projection(as.numeric(y),shape1 = pars2[1],shape2 = pars2[2])
+    c(i,lobato.statistic(yh),epps.statistic(yh))
+  })
 
-  rp.sample = list(lobato = x[1,],epps = x[2,])
+  x = rbind(matrix(unlist(x1),ncol = 3,byrow = TRUE),
+            matrix(unlist(x1),ncol = 3,byrow = TRUE))
+
+  rp.sample = list(lobato = x[,2],epps = x[,3])
 
   return(rp.sample)
 }

--- a/R/vavra_test.R
+++ b/R/vavra_test.R
@@ -225,14 +225,15 @@ sieve.bootstrap = function(y,reps = 1000,pmax = NULL,h = 100,seed = NULL){
   N = n + h
   sig = sd(mod$residuals)/sqrt(n-2*p-1)
 
-  sieve.step <- function(h) {
+  x <- parallel::mclapply(1:reps, FUN = function(i){
     N = n + h
     ar_boot <- arima.sim(n = N,model = list(ar = phi,sd = sig))
-    return(as.vector(ar_boot[(h+1):N]))
-  }
+    c(i,as.vector(ar_boot[(h+1):N]))
+  })
 
-  for_err <- replicate(reps, sieve.step(h))
-  return(t(for_err))
+  for_err <-matrix(unlist(x),ncol = n+1,byrow = TRUE)
+
+  return(for_err[,-1])
 }
 #' Anderson-Darling statistic
 #'

--- a/R/vavra_test.R
+++ b/R/vavra_test.R
@@ -200,20 +200,27 @@ sieve.bootstrap = function(y,reps = 1000,pmax = NULL,h = 100,seed = NULL){
     mod = forecast::auto.arima(y,d = 0,D = 0,max.p = pmax,
                                allowmean = TRUE,max.q = 0,
                                max.P = 0,max.Q = 0)
-    p = length(mod$coef)
+    p = length(mod$model$phi)
+    phi = mod$model$phi
   }
   else{
-    if(floor(log(n)^2)> pmax)
-      p = pmax
-    else
-      p = 1
+    p = ifelse(floor(log(n)^2) > pmax, pmax, floor(log(n)^2))
+
+    mod = forecast::auto.arima(y,d = 0,D = 0,max.p = pmax,
+                                 allowmean = TRUE,max.q = 0,
+                                 max.P = 0,max.Q = 0)
+
+    p = length(mod$model$phi)
+    phi = mod$model$phi
   }
 
-  if(p <= 0) p = 1
+  if(p <= 0){
+    p = 1
+    mod = stats::arima(y,order = c(p,0,0))
 
-  mod = stats::arima(y,order = c(p,0,0),include.mean = TRUE)
-  phi = mod$coef
-  p = length(phi)
+    p = length(mod$model$phi)
+    phi = mod$model$phi
+  }
 
   N = n + h
   sig = sd(mod$residuals)/sqrt(n-2*p-1)

--- a/tests/testthat/test-statistics.R
+++ b/tests/testthat/test-statistics.R
@@ -6,6 +6,12 @@ test_that("Vavra's statistic", {
   expect_equal(mean(ht), 0.4242066, tolerance = 0.3)
 })
 
+test_that("sieve_bootstrap",{
+  ht = nortsTest::sieve.bootstrap(y)
+  expect_equal(ncol(ht), length(y))
+  expect_equal(nrow(ht), 1000)
+})
+
 test_that("Lobato's statistic", {
   ht = nortsTest::lobato.statistic(y)
   expect_equal(ht, 1.3353, tolerance = 0.3)
@@ -22,4 +28,12 @@ test_that("Random Projections' statistics", {
   expect_equal(ht$lobato, 1.146889, tolerance = 0.3)
   #check computations are less than 2.5s
   expect_equal(ht$epps, 2.219923, tolerance = 0.3)
+})
+
+test_that("Random Projections' samples", {
+  ht = nortsTest::rp.sample(y)
+  # check the test choose the right hypothesis when using a Gaussian ARMA
+  expect_equal(length(ht$lobato), 32)
+  #check computations are less than 2.5s
+  expect_equal(length(ht$epps), 32)
 })


### PR DESCRIPTION
This PR replaces for loops with vectorized functions to speed up computations. The updated tests are:

 - vavra.test()
 - rp.test()